### PR TITLE
fix: latest version on pypi is not reflecting latest revision

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 
 [tool.poetry]
 name = "mkdocs-embed-external-markdown"
-version = "2.2.0"
+version = "2.3.0"
 description = "Mkdocs plugin that allow to inject external markdown or markdown section from given url"
 authors = ["fire1ce <dev@3os.org>"]
 license = "MIT"


### PR DESCRIPTION
The latest version in pypi is 2.2.1 but there is no revision in github for that number and the previous poetry.toml was at 2.1.2 I set it to 2.2.0, and the publish was successful, but due to the version inconsistency between pypi and github its not installing without the version being specified with pip install. Bumping to 2.3.0 so latest in pypi reflects latest revision.