### PR TITLE
Fix #11: Adapt link regex to exclude anchor links

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,20 @@ Install the package with pip:
 pip install mkdocs-embed-external-markdown
 ```
 
+### Installation for development
+
+To run the tests, first install the package and its test dependencies with pip:
+
+```shell
+pip install .[test]
+```
+
+You can now run the tests in `tests/` with `pytest`:
+
+```shell
+python -m pytest tests/
+```
+
 ## Configuration
 
 Enable the plugin in your `mkdocs.yml` file:

--- a/external_markdown/plugin.py
+++ b/external_markdown/plugin.py
@@ -9,7 +9,7 @@ from typing import Optional
 
 # Pre-compile regular expressions
 SECTION_LEVEL_REGEX = re.compile("^#+ ", re.IGNORECASE)
-LINK_PATTERN_REGEX = re.compile(r"\[(?P<alt_text>[^\]]*)\]\((?P<link_url>[^\)]*)\)", re.MULTILINE | re.IGNORECASE)
+LINK_PATTERN_REGEX = re.compile(r"\[(?P<alt_text>[^\]]*)\]\([^#](?P<link_url>[^\)]*)\)", re.MULTILINE | re.IGNORECASE)
 
 logger = logging.getLogger("mkdocs.plugins")
 

--- a/external_markdown/plugin.py
+++ b/external_markdown/plugin.py
@@ -9,7 +9,7 @@ from typing import Optional
 
 # Pre-compile regular expressions
 SECTION_LEVEL_REGEX = re.compile("^#+ ", re.IGNORECASE)
-LINK_PATTERN_REGEX = re.compile(r"\[(?P<alt_text>[^\]]*)\]\([^#](?P<link_url>[^\)]*)\)", re.MULTILINE | re.IGNORECASE)
+LINK_PATTERN_REGEX = re.compile(r"\[(?P<alt_text>[^\]]*)\]\((?P<link_url>[^\)]*)\)", re.MULTILINE | re.IGNORECASE)
 
 logger = logging.getLogger("mkdocs.plugins")
 
@@ -106,7 +106,9 @@ class EmbedExternalMarkdown(BasePlugin):
         """
 
         def replace_link(match):
-            link_url = urljoin(base_url, match.group("link_url"))
+            link_url = str(match.group("link_url"))
+            if not link_url.startswith("#"):
+                link_url = urljoin(base_url, link_url)
             return f'[{match.group("alt_text")}]({link_url})'
 
         return LINK_PATTERN_REGEX.sub(replace_link, markdown)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mkdocs-embed-external-markdown"
-version = "3.0.1"
+version = "3.0.2"
 description = "Mkdocs plugin that allow to inject external markdown or markdown section from given url"
 readme = {file = "README.md", content-type = "text/markdown"}
 authors = [{name = "Stas Yakobov", email = "dev@3os.org"}]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,10 @@ dependencies = [
 Source = 'https://github.com/fire1ce/pypi-test'
 
 [project.optional-dependencies]
+test = [
+  "pytest>=7.4.3",
+  "mkdocs>=1.5.3",
+]
 
 [project.scripts]
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,4 @@
 Jinja2==3.1.2
 requests==2.31.0
+pytest[test]==7.4.3
+mkdocs[test]==1.5.3

--- a/tests/external-markdown/test_plugin.py
+++ b/tests/external-markdown/test_plugin.py
@@ -1,0 +1,39 @@
+import pytest
+
+from external_markdown.plugin import EmbedExternalMarkdown
+
+BASE_URL = "https://BASEURL/"
+BASE_FILE = "https://BASEURL/FILE.md"
+TEST_DATA = [
+    (
+        "external link",
+        "https://github.com",
+        "https://github.com"),
+    (
+        "external link with anchor",
+        "https://ansible-docs.readthedocs.io/zh/stable-2.0/rst/playbooks_variables.html#using-variables-about-jinja2",
+        "https://ansible-docs.readthedocs.io/zh/stable-2.0/rst/playbooks_variables.html#using-variables-about-jinja2",
+    ),
+    (
+        "anchor",
+        "#links",
+        "#links"),
+    (
+        "local link",
+        "page.md",
+        f"{BASE_URL}page.md"),
+    (
+        "local link with anchor",
+        "page.md#test-subsection",
+        f"{BASE_URL}page.md#test-subsection",
+    ),
+]
+
+
+class TestEmbedExternalMarkdown:
+    @pytest.mark.parametrize("label,link_url,expected_url", TEST_DATA)
+    def test_update_relative_links_external(self, label, link_url, expected_url):
+        # Regression tests for #11
+        link = f"[{label}]({link_url})"
+        expected = f"[{label}]({expected_url})"
+        assert EmbedExternalMarkdown().update_relative_links(link, BASE_FILE) == expected


### PR DESCRIPTION
First up, thanks for a very helpful plugin!

I've stumbled over #11 just now and am supplying a fix in this PR.

- Changes the LINK_PATTERN_REGEX to only match links that don't start with a hash by adding `[^#]` in front of the `link_url` group.
- Manually tested locally with a vanilla page built with `mkdocs` v1.5.3 (`mkdocs new .`, add external page with anchor links, e.g., [this README](https://github.com/fefong/markdown_readme/blob/master/README.md): `{{ external_markdown('https://raw.githubusercontent.com/fefong/markdown_readme/master/README.md', '') }}`.

I hope this is acceptable. Please let me know shold you need anything changed, and feelf free to edit yourself.